### PR TITLE
Return promise on `sendMessage`

### DIFF
--- a/lib/channel.js
+++ b/lib/channel.js
@@ -82,22 +82,44 @@ C.sendOrEnqueue = function(method, fields, reply) {
   }
 };
 
+C.resolvePendingWrites = function () {
+  this.pendingWrites.forEach((promise) => {
+    promise.resolve();
+  });
+}
+
 C.waitForWrite = function () {
   return new Promise((resolve) => {
+    var writeCompleted = false;
     var buffer = this.connection.channels[this.ch].buffer;
+
     this.pendingWrites.push({resolve});
 
     if (buffer.listenerCount('inbound_empty') === 0) {
       buffer.once('inbound_empty', () => {
-        this.pendingWrites.forEach((promise) => {
-          promise.resolve();
-        });
+        writeCompleted = true;
+        this.resolvePendingWrites();
       });
     }
+
+    this.inboundTimeout = setTimeout(() => {
+      if (!writeCompleted) {
+        // inbound has reached the muxer, keep waiting
+        if (this.connection.muxer.newStreams.includes(buffer) || this.connection.muxer.oldStreams.includes(buffer)) {
+          return;
+        }
+
+        // inbound hasn't reached the muxer, it was likely written to Rabbit too quickly
+        // this should almost never happen
+        this.resolvePendingWrites();
+      }
+    }, 1000);
   });
 }
 
 C.sendMessage = function(fields, properties, content) {
+  clearTimeout(this.inboundTimeout);
+
   this.connection.sendMessage(
     this.ch,
     defs.BasicPublish, fields,

--- a/lib/channel.js
+++ b/lib/channel.js
@@ -27,6 +27,7 @@ function Channel(connection) {
   // for unconfirmed messages
   this.lwm = 1; // the least, unconfirmed deliveryTag
   this.unconfirmed = []; // rolling window of delivery callbacks
+  this.pendingWrites = [];
   this.on('ack', this.handleConfirm.bind(this, function(cb) {
     if (cb) cb(null);
   }));
@@ -81,12 +82,29 @@ C.sendOrEnqueue = function(method, fields, reply) {
   }
 };
 
+C.waitForWrite = function () {
+  return new Promise((resolve) => {
+    var buffer = this.connection.channels[this.ch].buffer;
+    this.pendingWrites.push({resolve});
+
+    if (buffer.listenerCount('inbound_empty') === 0) {
+      buffer.once('inbound_empty', () => {
+        this.pendingWrites.forEach((promise) => {
+          promise.resolve();
+        });
+      });
+    }
+  });
+}
+
 C.sendMessage = function(fields, properties, content) {
-  return this.connection.sendMessage(
+  this.connection.sendMessage(
     this.ch,
     defs.BasicPublish, fields,
     defs.BasicProperties, properties,
     content);
+
+   return this.waitForWrite();
 };
 
 // Internal, synchronously resolved RPC; the return value is resolved
@@ -186,7 +204,7 @@ C.toClosing = function(capturedStack, k) {
 };
 
 C._rejectPending = function() {
-  function rej(r) { 
+  function rej(r) {
     r(new Error("Channel ended, no reply will be forthcoming"));
   }
   if (this.reply !== null) rej(this.reply);
@@ -283,7 +301,7 @@ function acceptMessage(continuation) {
     if (f.id === defs.BasicProperties) {
       message.properties = f.fields;
       totalSize = remaining = f.size;
-      
+
       // for zero-length messages, content frames aren't required.
       if (totalSize === 0) {
         message.content = Buffer.alloc(0);
@@ -291,7 +309,7 @@ function acceptMessage(continuation) {
         return acceptDeliveryOrReturn;
       }
       else {
-        return content;        
+        return content;
       }
     }
     else {

--- a/lib/mux.js
+++ b/lib/mux.js
@@ -64,7 +64,10 @@ Mux.prototype._readIncoming = function() {
         if (chunk !== null) {
           accepting = out.write(chunk);
         }
-        else break;
+        else {
+          s.emit('inbound_empty');
+          break;
+        };
       }
       if (!accepting) streams.push(s);
     }
@@ -74,6 +77,8 @@ Mux.prototype._readIncoming = function() {
         if (chunk !== null) {
           accepting = out.write(chunk);
           streams.push(s);
+        } else {
+          s.emit('inbound_empty');
         }
       }
     }
@@ -105,7 +110,7 @@ Mux.prototype._readIncoming = function() {
 
 Mux.prototype._scheduleRead = function() {
   var self = this;
-  
+
   if (!self.scheduledRead) {
     schedule(function() {
       self.scheduledRead = false;


### PR DESCRIPTION
Welcome!

The strategy I used:

All messages are streamed to a passthrough, which is then written asynchronously to Rabbit in the `Muxer`.

I am now emitting an `inbound_empty` event from the Muxer signalling there there is no more data to write to rabbit.

Once this event is triggered, we resolve the promise.